### PR TITLE
add new observers

### DIFF
--- a/src/vivarium_csu_hypertension_sdc/model_specifications/model_spec.in
+++ b/src/vivarium_csu_hypertension_sdc/model_specifications/model_spec.in
@@ -7,7 +7,11 @@ components:
             - Risk("risk_factor.high_systolic_blood_pressure")
         metrics:
             - DisabilityObserver()
-            - MortalityObserver()
+            - DiseaseObserver("acute_myocardial_infarction")
+            - DiseaseObserver("post_myocardial_infarction")
+            - DiseaseObserver("ischemic_stroke")
+            - DiseaseObserver("subarachnoid_hemorrhage")
+            - DiseaseObserver("intracerebral_hemorrhage")
 
     vivarium_csu_hypertension_sdc.components:
         - IschemicHeartDisease()
@@ -26,6 +30,9 @@ components:
         - TreatmentEffect()
         - TreatmentAlgorithm()
         #- SimulantTrajectoryObserver()
+        - MedicationObserver()
+        - HtnMortalityObserver()
+        - SBPTimeSeriesObserver()
 
 configuration:
     input_data:
@@ -60,6 +67,30 @@ configuration:
             by_sex: True
             by_year: False
         mortality:
+            by_age: True
+            by_sex: True
+            by_year: False
+        medication:
+            by_age: True
+            by_sex: True
+            by_year: False
+        acute_myocardial_infarction_observer:
+            by_age: True
+            by_sex: True
+            by_year: False
+        post_myocardial_infarction_observer:
+            by_age: True
+            by_sex: True
+            by_year: False
+        ischemic_stroke_observer:
+            by_age: True
+            by_sex: True
+            by_year: False
+        subarchnoid_hemorrhage_observer:
+            by_age: True
+            by_sex: True
+            by_year: False
+        intracerebral_hemorrhage_observer:
             by_age: True
             by_sex: True
             by_year: False


### PR DESCRIPTION
Ok this adds the observers + config flags to the template. I tested all the observers I wrote. I couldn't test the disease observers to make sure I have all the right column names because the vpn kept crashing my computer :roll_eyes: so I couldn't get to the artifacts with the disease data. I double checked the code though and it doesn't look like it has the same issue as the mort/disability observers because it just looks for the column that matches the disease name it's initialized with. 